### PR TITLE
fix : 서버 시작시 api 상태 검사하는 CheckOpenApi 메소드 삭제(CacheBackupService와 연동하면…

### DIFF
--- a/src/main/java/com/scaling/libraryservice/commons/caching/CustomCacheAspect.java
+++ b/src/main/java/com/scaling/libraryservice/commons/caching/CustomCacheAspect.java
@@ -64,7 +64,7 @@ public class CustomCacheAspect<T> {
 
         log.info("........."+taskTime);
 
-        if (taskTime >= 0.4 ||
+        if (taskTime > 1.0 ||
             clazz == MapBookService.class) {
 
             log.info("This task is over 0.5s [{}] or related MapBookService then CacheManger put this item : [{}] ",taskTime,result);

--- a/src/main/java/com/scaling/libraryservice/commons/logging/LogParserExecutor.java
+++ b/src/main/java/com/scaling/libraryservice/commons/logging/LogParserExecutor.java
@@ -1,0 +1,135 @@
+package com.scaling.libraryservice.commons.logging;
+
+import com.google.gson.Gson;
+import java.io.BufferedReader;
+import java.io.BufferedWriter;
+import java.io.FileReader;
+import java.io.FileWriter;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+import lombok.Getter;
+import lombok.Setter;
+
+
+public class LogParserExecutor {
+
+    public static void main(String[] args) {
+        String inputNm = "logs/test_book_log0506.log"; // 로그 파일 이름을 입력합니다.
+        String outputNm = "logs/test_book_ver1_cache_duration.json";
+
+        executeParse(inputNm, outputNm);
+    }
+
+    @Getter
+    @Setter
+    static class LogData {
+
+        String query;
+        String titleQuery;
+        String duration;
+
+        public LogData() {
+        }
+
+        public LogData(String query, String titleQuery, String duration) {
+            this.query = query;
+            this.titleQuery = titleQuery;
+            this.duration = duration;
+        }
+
+
+        @Override
+        public String toString() {
+            return "LogData{" +
+                "query='" + query + '\'' +
+                ", titleQuery='" + titleQuery + '\'' +
+                ", duration=" + duration +
+                '}';
+        }
+    }
+
+    private static void executeParse(String inputFile, String outputFile) {
+
+        Gson gson = new Gson();
+
+        try {
+
+            List<LogData> logDataList = parseLogData(inputFile);
+
+            var result = gson.toJson(logDataList);
+
+            FileWriter fileWriter = new FileWriter(outputFile);
+            BufferedWriter bufferedWriter = new BufferedWriter(fileWriter);
+
+            logDataList.stream().forEach(l -> {
+                try {
+                    if (l.getDuration() != null) {
+                        bufferedWriter.write(l.getDuration() + "\n");
+                    }
+                } catch (IOException e) {
+                    throw new RuntimeException(e);
+                }
+            });
+
+            bufferedWriter.close();
+
+        } catch (IOException e) {
+            e.printStackTrace();
+        }
+    }
+
+    private static List<LogData> parseLogData(String fileName) throws IOException {
+        List<LogData> logDataList = new ArrayList<>();
+
+        try (BufferedReader br = new BufferedReader(new FileReader(fileName))) {
+            String line;
+            String query = "";
+            String titleQuery = "";
+            String duration = "";
+
+            Pattern queryPattern = Pattern.compile("query : \\[(.+?)\\]");
+            Pattern titleQueryPattern = Pattern.compile("TitleQuery\\((.+?)\\)");
+            Pattern durationPattern = Pattern.compile("\\[(\\d+\\.\\d+)s\\]");
+            Pattern classPattern = Pattern.compile(
+                "\\[com\\.scaling\\.libraryservice\\.search\\.service\\.BookSearchService\\]");
+
+            while ((line = br.readLine()) != null) {
+                Matcher queryMatcher = queryPattern.matcher(line);
+                Matcher titleQueryMatcher = titleQueryPattern.matcher(line);
+                Matcher durationMatcher = durationPattern.matcher(line);
+                Matcher classMatcher = classPattern.matcher(line);
+
+                LogData logData = new LogData();
+
+                if (queryMatcher.find()) {
+                    query = queryMatcher.group(1);
+                    logData.setQuery(query);
+                }
+                if (titleQueryMatcher.find()) {
+                    titleQuery = titleQueryMatcher.group(1);
+
+                    logData.setTitleQuery(titleQuery);
+                }
+
+                if (classMatcher.find()) {
+                    if (durationMatcher.find()) {
+
+                        duration = durationMatcher.group(1);
+
+                            logData.setDuration(duration);
+                    }
+                }
+                logDataList.add(logData);
+            }
+        }
+
+        return logDataList;
+    }
+
+}
+
+
+

--- a/src/main/java/com/scaling/libraryservice/mapBook/controller/MapBookController.java
+++ b/src/main/java/com/scaling/libraryservice/mapBook/controller/MapBookController.java
@@ -26,11 +26,6 @@ public class MapBookController {
 
     private final LibraryFindService libraryFindService;
 
-    @PostConstruct
-    public void init() {
-        mapBookService.checkOpenApi();
-    }
-
 
     /**
      * 사용자의 요청에 맞는 대출 가능 도서관 마커 데이터를 model에 담아 view에 전달 합니다

--- a/src/main/java/com/scaling/libraryservice/mapBook/dto/ApiStatus.java
+++ b/src/main/java/com/scaling/libraryservice/mapBook/dto/ApiStatus.java
@@ -11,7 +11,7 @@ import org.joda.time.DateTime;
 public class ApiStatus {
 
     private final String apiUri;
-    private boolean apiAccessible;
+    private boolean apiAccessible = true;
     private int errorCnt;
     private DateTime closedTime;
     private DateTime openedTime;

--- a/src/main/java/com/scaling/libraryservice/mapBook/service/MapBookService.java
+++ b/src/main/java/com/scaling/libraryservice/mapBook/service/MapBookService.java
@@ -7,10 +7,8 @@ import com.scaling.libraryservice.commons.caching.CacheBackupService;
 import com.scaling.libraryservice.commons.caching.CacheKey;
 import com.scaling.libraryservice.commons.caching.CustomCacheManager;
 import com.scaling.libraryservice.commons.caching.CustomCacheable;
-import com.scaling.libraryservice.commons.circuitBreaker.CircuitBreaker;
 import com.scaling.libraryservice.commons.timer.Timer;
 import com.scaling.libraryservice.mapBook.dto.ApiBookExistDto;
-import com.scaling.libraryservice.mapBook.dto.ApiStatus;
 import com.scaling.libraryservice.mapBook.dto.LibraryDto;
 import com.scaling.libraryservice.mapBook.dto.ReqMapBookDto;
 import com.scaling.libraryservice.mapBook.dto.RespMapBookDto;
@@ -54,21 +52,6 @@ public class MapBookService {
         }
 
         customCacheManager.registerCaching(mapBookCache, this.getClass());
-    }
-
-    public void checkOpenApi() {
-
-        BExistConn bExistConn = new BExistConn();
-        ApiStatus status = BExistConn.apiStatus;
-
-        ResponseEntity<String> connection
-            = apiQuerySender.singleQueryJson(bExistConn, "9788089365210");
-
-        if (apiQueryBinder.bindBookExist(connection) == null) {
-            CircuitBreaker.closeObserver(status);
-        } else {
-            status.openAccess();
-        }
     }
 
     /**

--- a/src/main/java/com/scaling/libraryservice/search/service/BookSearchService.java
+++ b/src/main/java/com/scaling/libraryservice/search/service/BookSearchService.java
@@ -76,7 +76,7 @@ public class BookSearchService {
     @CustomCacheable
     public RespBooksDto searchBooks(String query, int page, int size, String target) {
 
-        log.info("-------------query : [{}]-------------------------------",query);
+        log.info("-------------query : [{}]-------------------------------", query);
 
         Pageable pageable = PageRequest.of(page - 1, size);
         Page<Book> books = null;
@@ -87,9 +87,8 @@ public class BookSearchService {
         } catch (InterruptedException | ExecutionException | TimeoutException e) {
             log.error("Query execution exceeded 3 seconds. Returning an empty result.", e);
             books = Page.empty(pageable);
-            asyncSearchBook(query,page,size);
+            asyncSearchBook(query, page, size);
         }
-
 
         Objects.requireNonNull(books);
 
@@ -99,9 +98,9 @@ public class BookSearchService {
             books.stream().map(BookDto::new).toList());
     }
 
-    public void asyncSearchBook(String query, int page,int size){
+    public void asyncSearchBook(String query, int page, int size) {
         Pageable pageable = PageRequest.of(page - 1, size);
-        log.info("[{}] async Search Book start.....",query);
+        log.info("[{}] async Search Book start.....", query);
         var result = CompletableFuture.runAsync(() -> {
             Page<Book> fetchedBooks = pickSelectQuery(query, pageable);
             if (fetchedBooks != null && !fetchedBooks.isEmpty()) {
@@ -110,8 +109,8 @@ public class BookSearchService {
                         fetchedBooks.getTotalElements(), page, size),
                     fetchedBooks.stream().map(BookDto::new).toList());
 
-                cacheManager.put(this.getClass(),new BookCacheKey(query,page),respBooksDto);
-                log.info("[{}] async Search task is Completed",query);
+                cacheManager.put(this.getClass(), new BookCacheKey(query, page), respBooksDto);
+                log.info("[{}] async Search task is Completed", query);
             }
         });
     }
@@ -130,7 +129,7 @@ public class BookSearchService {
 
         TitleType type = titleQuery.getTitleType();
 
-        log.info("Query is [{}] and tokens : [{}]",type.name(),titleQuery);
+        log.info("Query is [{}] and tokens : [{}]", type.name(), titleQuery);
 
         switch (type) {
 
@@ -147,7 +146,8 @@ public class BookSearchService {
                 return bookRepository.findBooksByEngMtFlexible(titleQuery.getEngToken(), pageable);
             }
             case KOR_ENG, ENG_KOR_SG -> {
-                return bookRepository.findBooksByEngKorBool(titleQuery.getEngToken(),titleQuery.getKorToken(), pageable);
+                return bookRepository.findBooksByEngKorBool(titleQuery.getEngToken(),
+                    titleQuery.getKorToken(), pageable);
             }
 
             case ENG_KOR_MT -> {

--- a/src/main/java/com/scaling/libraryservice/search/util/TitleAnalyzer.java
+++ b/src/main/java/com/scaling/libraryservice/search/util/TitleAnalyzer.java
@@ -39,14 +39,7 @@ public class TitleAnalyzer {
     @Timer
     public TitleQuery analyze(String query) {
 
-        if (query.contains(":")) {
-            int idx = query.indexOf(":");
-            query = query.substring(0, idx);
-        }
-
-        /*if(query.startsWith("(") & query.indexOf(")") != query.length()-1){
-            query = query.substring(query.indexOf(")")+1);
-        }*/
+        query = trimSubTitle(query);
 
         if (isEnglish(query)) {
 
@@ -63,6 +56,19 @@ public class TitleAnalyzer {
             log.info("korean & english title : [{}]", query);
             return engKorResolve(query);
         }
+    }
+
+    private String trimSubTitle(String query){
+        if (query.contains(":") ) {
+            int idx = query.indexOf(":");
+            String foreTitle = query.substring(0, idx);
+
+            if(foreTitle.split(" ").length >1){
+                query = foreTitle;
+            }
+        }
+
+        return query;
     }
 
     /**
@@ -108,7 +114,7 @@ public class TitleAnalyzer {
      */
     private TitleQuery engKorResolve(String query) {
 
-        Map<String, List<String>> titleMap = TitleDivider.divideTitle(query);
+        Map<String, List<String>> titleMap = TitleDivider.divideKorEng(query);
 
         List<String> engTokens = titleMap.get("eng").stream()
             .max(Comparator.comparing(String::length))
@@ -174,7 +180,7 @@ public class TitleAnalyzer {
      * @return 영어 제목이면 true, 그 외에는 false;
      */
     public static boolean isEnglish(String input) {
-        String pattern = "^[a-zA-Z0-9\\.\\s]+$";
+        String pattern = "^[a-zA-Z0-9\\.\\s:,;?!\\-()\\[\\]{}<>]+$";
         return input.matches(pattern);
     }
 
@@ -185,7 +191,7 @@ public class TitleAnalyzer {
      * @return 한글 제목이면 true, 그 외에는 false
      */
     public static boolean isKorean(String input) {
-        String pattern = "^[가-힣0-9\\.\\s]+$";
+        String pattern = "^[가-힣0-9\\.\\s:,;?!\\-()\\[\\]{}<>]+$";
         return input.matches(pattern);
     }
 

--- a/src/main/java/com/scaling/libraryservice/search/util/TitleDivider.java
+++ b/src/main/java/com/scaling/libraryservice/search/util/TitleDivider.java
@@ -18,7 +18,7 @@ public class TitleDivider {
      * @return 영어와 한글로 분리된 검색어가 담긴 Map 객체 (키: "eng" - 영어, "kor" - 한글)
      */
     @Timer
-    public static Map<String, List<String>> divideTitle(String query) {
+    public static Map<String, List<String>> divideKorEng(String query) {
 
         char[] chars = query.toCharArray();
 

--- a/src/test/java/com/scaling/libraryservice/LearningTest.java
+++ b/src/test/java/com/scaling/libraryservice/LearningTest.java
@@ -3,11 +3,7 @@ package com.scaling.libraryservice;
 import com.github.benmanes.caffeine.cache.Cache;
 import com.github.benmanes.caffeine.cache.Caffeine;
 import com.google.gson.Gson;
-import com.google.gson.JsonElement;
-import com.google.gson.JsonObject;
-import com.google.gson.JsonParser;
 import com.scaling.libraryservice.commons.apiConnection.BExistConn;
-import com.scaling.libraryservice.commons.caching.CacheBackupService;
 import com.scaling.libraryservice.commons.caching.UserInfo;
 import com.scaling.libraryservice.mapBook.cacheKey.HasBookCacheKey;
 import com.scaling.libraryservice.mapBook.controller.MapBookController;
@@ -178,7 +174,7 @@ public class LearningTest {
     public void english_korean() {
         String text = "e-mail에 꼭 필요한 알짜표현";
 
-        var result = TitleDivider.divideTitle(text);
+        var result = TitleDivider.divideKorEng(text);
 
         System.out.println(result);
     }


### PR DESCRIPTION
…서 에러) -> 처음 시작을 api 연결이 true로 설정. TitleAnalyzer의 내부 로직을 내부 메소드로 변경. TitleDivider 메소드 이름 변경 // Cache 되는 검색 시간 기준을 1.0 초과로 변경