### PR TITLE
Fix/front image

### DIFF
--- a/src/main/java/com/scaling/libraryservice/search/dto/BookDto.java
+++ b/src/main/java/com/scaling/libraryservice/search/dto/BookDto.java
@@ -36,12 +36,6 @@ public class BookDto {
         this.author = book.getAuthor();
         this.isbn = book.getIsbn();
         this.bookImg =book.getBookImg();
-
-        if (book.getBookImg().isEmpty()) {
-            this.bookImg = "[내용 없음]";
-        } else {
-            this.bookImg = book.getBookImg();
-        }
     }
 
     public BookDto(BookDto bookDto) {

--- a/src/main/resources/templates/search/searchResult.html
+++ b/src/main/resources/templates/search/searchResult.html
@@ -68,7 +68,7 @@
         <td th:text="${book.author}"></td>
         <td th:text="${book.content}"></td>
         <td>
-          <img class="book-image" th:src="${book.bookImg}" alt="준비중" src="../../static/images/empty.jpeg"/>
+          <img class="book-image" th:attr="src=${!book.bookImg.isEmpty() ? book.bookImg : 'https://someone-be-bucket.s3.ap-northeast-2.amazonaws.com/mapbook+logo.png'}" alt="준비중"/>
         </td>
         <td>
           <button class="loan-check-btn" th:data-isbn="${book.isbn}" onsubmit="return openPopup_MapBook()">


### PR DESCRIPTION
원인

SearchResult.html에서 도서 결과들을 표로 표시하는 태그 중 타임리프를 쓰는
준비중 이 부분에서 오류가 있었습니다.
주된 오류는 bookImg가 isEmpty일 때 분기해서 대체 이미지로 바꿔줘야 하는데, 그러지 못해서 일어난 문제라고 판단 됩니다.

또한 프론트 단에 book 데이터를 처리 해주는 서버 로직 BootDto 파트에서

if (book.getBookImg().isEmpty()) {
this.bookImg = "[내용 없음]";
} else {
this.bookImg = book.getBookImg();
}

 라고 하는 부분에서 DB에서 img Url이 없으면 [내용 없음]으로 대체 되기 때문에 프론트 영역에서 분기 처리하기 번거로워 지기 때문에
 
 해당 부분 삭제하고, String 변수이기 때문에 DB에서 null이면 자동으로 ""으로 초기화 되서 isEmpty로 프론트 영역에서 처리 할 수 있게 바꿨습니다.
 
 2. 마지막으로 이미지 경로 오류가 나올 수 있어, 대체 이미지는 S3를 통해서 이미지를 가져오는 형태로 변경 했습니다.