### PR TITLE
refactor : 1) TitleQuery Builder 적용하여 TitleAnalyzer에서 사용하던 생성자 방식을 빌더…

### DIFF
--- a/src/main/java/com/scaling/libraryservice/search/domain/TitleQuery.java
+++ b/src/main/java/com/scaling/libraryservice/search/domain/TitleQuery.java
@@ -1,27 +1,47 @@
 package com.scaling.libraryservice.search.domain;
 
+import lombok.Builder;
 import lombok.Getter;
-import lombok.RequiredArgsConstructor;
+import lombok.NonNull;
 import lombok.ToString;
+import org.springframework.lang.Nullable;
 
 /**
- * 검색 쿼리를 분석한 결과를 저장하기 위한 클래스입니다.
- * 각 검색어 토큰과 검색어 유형(TitleType)에 대한 정보를 저장합니다.
+ * 검색 쿼리를 분석한 결과를 저장하기 위한 클래스입니다. 각 검색어 토큰과 검색어 유형(TitleType)에 대한 정보를 저장합니다.
  */
-@RequiredArgsConstructor
-@ToString @Getter
+@ToString
+@Getter
+@Builder
 public class TitleQuery {
 
-    /** 검색어 유형 정보를 저장하는 변수 */
+
+    /**
+     * 검색어 유형 정보를 저장하는 변수
+     */
     private final TitleType titleType;
 
-    /** 영어 검색어 토큰을 저장하는 변수 */
+    /**
+     * 영어 검색어 토큰을 저장하는 변수
+     */
     private final String engToken;
 
-    /** 한국어 검색어 토큰을 저장하는 변수 */
+    /**
+     * 한국어 검색어 토큰을 저장하는 변수
+     */
     private final String korToken;
 
-    /** 영어와 한국어 혼합된 검색어 토큰을 저장하는 변수 */
+    /**
+     * 영어와 한국어 혼합된 검색어 토큰을 저장하는 변수
+     */
     private final String engKorToken;
+
+    private TitleQuery(@NonNull TitleType titleType, @Nullable String engToken,
+        @Nullable String korToken, @Nullable String engKorToken) {
+
+        this.titleType = titleType;
+        this.engToken = engToken;
+        this.korToken = korToken;
+        this.engKorToken = engKorToken;
+    }
 
 }

--- a/src/main/java/com/scaling/libraryservice/search/util/TitleDivider.java
+++ b/src/main/java/com/scaling/libraryservice/search/util/TitleDivider.java
@@ -19,74 +19,52 @@ public class TitleDivider {
      */
     @Timer
     public static Map<String, List<String>> divideKorEng(String query) {
-
         char[] chars = query.toCharArray();
 
-        StringBuilder engBuffer = new StringBuilder();
-        StringBuilder korBuffer = new StringBuilder();
+        StringBuilder engBuilder = new StringBuilder();
+        StringBuilder korBuilder = new StringBuilder();
 
         List<String> eng = new ArrayList<>();
         List<String> kor = new ArrayList<>();
 
-        boolean engFirst = true;
-        boolean korFirst = true;
-
         for (char c : chars) {
-
-            if (c <= 122 & c >= 46) {
-                if (!korBuffer.isEmpty()) {
-                    kor.add(korBuffer.toString());
-                    korBuffer.setLength(0);
-
-                    engFirst = true;
+            if (c >= 'A' && c <= 'z') {
+                if (korBuilder.length() > 0) {
+                    kor.add(korBuilder.toString());
+                    korBuilder.setLength(0);
                 }
-
-                if (c == ' ' & engFirst) {
-
-                } else {
-                    if (c >= 46) {
-                        engBuffer.append(c);
-                        engFirst = false;
-                    }
-
+                engBuilder.append(c);
+            } else if (c >= '가' && c <= '힣') {
+                if (engBuilder.length() > 0) {
+                    eng.add(engBuilder.toString());
+                    engBuilder.setLength(0);
                 }
-
-            } else {
-
-                if (!engBuffer.isEmpty()) {
-
-                    eng.add(engBuffer.toString());
-                    engBuffer.setLength(0);
-
-                    korFirst = true;
+                korBuilder.append(c);
+            } else if (c == ' ') {
+                if (engBuilder.length() > 0) {
+                    eng.add(engBuilder.toString());
+                    engBuilder.setLength(0);
                 }
-
-                if (c == ' ' & !korFirst) {
-                    korBuffer.append(c);
-                } else {
-                    if (c > 47) {
-                        korBuffer.append(c);
-                        korFirst = false;
-                    }
+                if (korBuilder.length() > 0) {
+                    kor.add(korBuilder.toString());
+                    korBuilder.setLength(0);
                 }
-
             }
         }
 
-        if (!engBuffer.isEmpty()) {
-            eng.add(engBuffer.toString());
+        if (engBuilder.length() > 0) {
+            eng.add(engBuilder.toString());
         }
-
-        if (!korBuffer.isEmpty()) {
-            kor.add(korBuffer.toString());
+        if (korBuilder.length() > 0) {
+            kor.add(korBuilder.toString());
         }
 
         Map<String, List<String>> result = new HashMap<>();
-
         result.put("eng", eng);
         result.put("kor", kor);
 
         return result;
     }
+
 
 }

--- a/src/main/java/com/scaling/libraryservice/search/util/TitleTokenizer.java
+++ b/src/main/java/com/scaling/libraryservice/search/util/TitleTokenizer.java
@@ -26,10 +26,10 @@ public class TitleTokenizer {
 
         KomoranResult analyzeResultList = komoran.analyze(target);
 
-        List<Token> tokenList = analyzeResultList.getTokenList();
+        List<Token> tokens = analyzeResultList.getTokenList();
 
         List<String> nounList =
-            tokenList.stream().filter(i ->  i.getPos().equals("NNP") | i.getPos().equals("NNG"))
+            tokens.stream().filter(i ->  i.getPos().equals("NNP") | i.getPos().equals("NNG"))
                 .map(Token::getMorph).toList();
 
         return nounList.stream().distinct().filter(non -> non.length()>1).toList();

--- a/src/test/java/com/scaling/libraryservice/search/domain/TitleQueryTest.java
+++ b/src/test/java/com/scaling/libraryservice/search/domain/TitleQueryTest.java
@@ -1,0 +1,22 @@
+package com.scaling.libraryservice.search.domain;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import org.junit.jupiter.api.Test;
+
+class TitleQueryTest {
+
+    @Test
+    public void test_build(){
+        /* given */
+
+        var result = TitleQuery.builder().titleType(TitleType.KOR_MT_OVER_TWO).korToken("hi").build();
+
+        /* when */
+
+        /* then */
+
+        System.out.println(result);
+    }
+
+}

--- a/src/test/java/com/scaling/libraryservice/search/service/BookSearchServiceTest.java
+++ b/src/test/java/com/scaling/libraryservice/search/service/BookSearchServiceTest.java
@@ -1,9 +1,13 @@
 package com.scaling.libraryservice.search.service;
 
 import com.scaling.libraryservice.commons.caching.CustomCacheManager;
+import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
 import com.scaling.libraryservice.search.cacheKey.BookCacheKey;
 import com.scaling.libraryservice.search.dto.RespBooksDto;
 import com.scaling.libraryservice.search.entity.Book;
+import com.scaling.libraryservice.search.util.TitleAnalyzer;
 import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -19,6 +23,9 @@ class BookSearchServiceTest {
 
     @Autowired
     private BookSearchService bookSearchService;
+
+    @Autowired
+    private TitleAnalyzer titleAnalyzer;
 
 
     @Test
@@ -37,7 +44,7 @@ class BookSearchServiceTest {
 
         RespBooksDto result = bookSearchService.searchBooks(new BookCacheKey(title,page), size, target);
 
-        Assertions.assertThat(result.getDocuments().get(0).getTitle().contains(title));
+        assertTrue(result.getDocuments().get(0).getTitle().contains(title));
 
     }
 
@@ -49,9 +56,13 @@ class BookSearchServiceTest {
         String title = "자바";
         Pageable pageable = PageRequest.of(0, 10);
 
-        Page<Book> result = bookSearchService.pickSelectQuery(title, pageable);
+        var titleQuery= titleAnalyzer.analyze(title);
+
+        Page<Book> result = bookSearchService.pickSelectQuery(titleQuery, pageable);
 
         System.out.println("결과: " + result.getContent().get(0).getTitle().contains(title));
+
+        assertTrue(result.getContent().get(0).getTitle().contains(title));
 
     }
 
@@ -62,9 +73,11 @@ class BookSearchServiceTest {
         String title = "그리스 로마 신화";
         Pageable pageable = PageRequest.of(0, 10);
 
-        Page<Book> result = bookSearchService.pickSelectQuery(title, pageable);
+        var titleQuery= titleAnalyzer.analyze(title);
 
-        Assertions.assertThat(result.getContent().get(0).getTitle().contains(title));
+        Page<Book> result = bookSearchService.pickSelectQuery(titleQuery, pageable);
+
+        assertTrue(result.getContent().get(0).getTitle().contains(title));
 
     }
 
@@ -75,9 +88,11 @@ class BookSearchServiceTest {
         String title = "java";
         Pageable pageable = PageRequest.of(0, 10);
 
-        Page<Book> result = bookSearchService.pickSelectQuery(title, pageable);
+        var titleQuery= titleAnalyzer.analyze(title);
 
-        Assertions.assertThat(result.getContent().get(0).getTitle().contains(title));
+        Page<Book> result = bookSearchService.pickSelectQuery(titleQuery, pageable);
+
+        assertTrue(result.getContent().get(0).getTitle().contains(title));
 
     }
 
@@ -88,9 +103,11 @@ class BookSearchServiceTest {
         String title = "자바의 정석";
         Pageable pageable = PageRequest.of(0, 10);
 
-        Page<Book> result = bookSearchService.pickSelectQuery(title, pageable);
+        var titleQuery= titleAnalyzer.analyze(title);
 
-        Assertions.assertThat(result.getContent().get(0).getTitle().contains(title));
+        Page<Book> result = bookSearchService.pickSelectQuery(titleQuery, pageable);
+
+        assertTrue(result.getContent().get(0).getTitle().contains(title));
 
     }
 
@@ -101,9 +118,11 @@ class BookSearchServiceTest {
         String title = "spring boot";
         Pageable pageable = PageRequest.of(0, 10);
 
-        Page<Book> result = bookSearchService.pickSelectQuery(title, pageable);
+        var titleQuery= titleAnalyzer.analyze(title);
 
-        Assertions.assertThat(result.getContent().get(0).getTitle().contains(title));
+        Page<Book> result = bookSearchService.pickSelectQuery(titleQuery, pageable);
+
+        assertTrue(result.getContent().get(0).getTitle().contains(title));
 
     }
 
@@ -114,9 +133,11 @@ class BookSearchServiceTest {
         String title = "java 정석";
         Pageable pageable = PageRequest.of(0, 10);
 
-        Page<Book> result = bookSearchService.pickSelectQuery(title, pageable);
+        var titleQuery= titleAnalyzer.analyze(title);
 
-        Assertions.assertThat(result.getContent().get(0).getTitle().contains(title));
+        Page<Book> result = bookSearchService.pickSelectQuery(titleQuery, pageable);
+
+        assertTrue(result.getContent().get(0).getTitle().contains(title));
 
     }
 

--- a/src/test/java/com/scaling/libraryservice/search/util/TitleDividerTest.java
+++ b/src/test/java/com/scaling/libraryservice/search/util/TitleDividerTest.java
@@ -1,0 +1,26 @@
+package com.scaling.libraryservice.search.util;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import java.util.stream.Collectors;
+import org.junit.jupiter.api.Test;
+
+class TitleDividerTest {
+
+    @Test
+    public void test_divide(){
+        /* given */
+
+        String title = "java 정석";
+
+        /* when */
+
+        var result = TitleDivider.divideKorEng(title);
+
+        /* then */
+
+        assertEquals(String.join("", result.get("eng")), "java");
+        assertEquals(String.join("", result.get("kor")), "정석");
+    }
+
+}


### PR DESCRIPTION
… 방식으로 변경(생성자 매개 변수 4개는 많다고 판단) 2) TitleAnalyzer의 resolve 메소드 안의 내부 로직이 가독성이 떨어진다고 판단하여 내부 메소드로 분리. 3) BookSearchService의 pickSelectQuery 내부에서 titleAnalyzer.analyze(query); 호출을 밖으로 분리 (매개 변수에 TitleQuery 추가) 4) TitleDivider 내부 로직 구조 변경(로직의 변화는 없음)