### PR TITLE
refactor : 기존에 API 결과 Binding 전략을 appConfig에서 전략 구현체를 일일이 지정 해주는 방식 -…

### DIFF
--- a/src/main/java/com/scaling/libraryservice/commons/api/service/provider/BExistProvider.java
+++ b/src/main/java/com/scaling/libraryservice/commons/api/service/provider/BExistProvider.java
@@ -12,8 +12,10 @@ import javax.annotation.PostConstruct;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpEntity;
 import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Component;
 
 @RequiredArgsConstructor
+@Component
 public class BExistProvider implements DataProvider<ApiBookExistDto>{
 
     private final ApiQuerySender apiQuerySender;
@@ -34,6 +36,6 @@ public class BExistProvider implements DataProvider<ApiBookExistDto>{
         List<ResponseEntity<String>> responseEntities =
             apiQuerySender.sendMultiQuery(connections, nThreads, HttpEntity.EMPTY);
 
-        return apiQueryBinder.bindList(responseEntities);
+        return apiQueryBinder.bindList(responseEntities,this.getClass());
     }
 }

--- a/src/main/java/com/scaling/libraryservice/commons/api/service/provider/KakaoBookProvider.java
+++ b/src/main/java/com/scaling/libraryservice/commons/api/service/provider/KakaoBookProvider.java
@@ -11,9 +11,11 @@ import java.util.List;
 import javax.annotation.PostConstruct;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Component;
 
 
 @RequiredArgsConstructor
+@Component
 public class KakaoBookProvider implements DataProvider<BookApiDto> {
 
     private final ApiQuerySender apiQuerySender;
@@ -33,7 +35,7 @@ public class KakaoBookProvider implements DataProvider<BookApiDto> {
         List<ResponseEntity<String>> responseEntities = apiQuerySender.sendMultiQuery(connections,
             nThreads, new KakaoBookConn("", 1L).getHttpEntity());
 
-        return apiQueryBinder.bindList(responseEntities);
+        return apiQueryBinder.bindList(responseEntities,this.getClass());
     }
 
 }

--- a/src/main/java/com/scaling/libraryservice/commons/api/util/ApiQueryBinder.java
+++ b/src/main/java/com/scaling/libraryservice/commons/api/util/ApiQueryBinder.java
@@ -1,25 +1,38 @@
 package com.scaling.libraryservice.commons.api.util;
 
+import com.scaling.libraryservice.commons.api.service.provider.BExistProvider;
+import com.scaling.libraryservice.commons.api.service.provider.KakaoBookProvider;
 import com.scaling.libraryservice.commons.api.util.binding.BindingStrategy;
+import com.scaling.libraryservice.commons.api.util.binding.BookExistBinding;
+import com.scaling.libraryservice.commons.api.util.binding.KakaoBookBinding;
 import com.scaling.libraryservice.mapBook.exception.OpenApiException;
+import java.util.HashMap;
 import java.util.List;
-import lombok.RequiredArgsConstructor;
+import java.util.Map;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.ResponseEntity;
 import org.springframework.lang.NonNull;
+import org.springframework.stereotype.Component;
 
-@Slf4j
-@RequiredArgsConstructor
+@Slf4j @Component
 public class ApiQueryBinder<T> {
 
-    private final BindingStrategy<T> bindingStrategy;
+    private final Map<Class<?>,BindingStrategy<?>> bindingStrategyMap;
 
-    public T bind(ResponseEntity<String> apiResponse) throws OpenApiException {
-        return bindingStrategy.bind(apiResponse);
+    public ApiQueryBinder() {
+        this.bindingStrategyMap = new HashMap<>();
+
+        bindingStrategyMap.put(KakaoBookProvider.class,new KakaoBookBinding());
+        bindingStrategyMap.put(BExistProvider.class,new BookExistBinding());
     }
 
-    public List<T> bindList(@NonNull List<ResponseEntity<String>> apiResponses) throws OpenApiException {
-        return apiResponses.stream().map(this::bind).toList();
+    public T bind(ResponseEntity<String> apiResponse,Class<?> provider) throws OpenApiException {
+        return (T) bindingStrategyMap.get(provider).bind(apiResponse);
+    }
+
+    public List<T> bindList(@NonNull List<ResponseEntity<String>> apiResponses, Class<?> provider) throws OpenApiException {
+
+        return apiResponses.stream().map(r -> bind(r,provider)).toList();
     }
 
 }

--- a/src/main/java/com/scaling/libraryservice/config/AppConfig.java
+++ b/src/main/java/com/scaling/libraryservice/config/AppConfig.java
@@ -79,34 +79,5 @@ public class AppConfig {
     }
 
 
-    @Bean
-    public BindingStrategy<BookApiDto> kakaoBinding() {
-
-        return new KakaoBookBinding();
-    }
-
-    @Bean
-    public BindingStrategy<ApiBookExistDto> bookExistBinding() {
-
-        return new BookExistBinding();
-    }
-
-    @Bean
-    public KakaoBookProvider kakaoBookProvider(AuthKeyLoader loader) {
-
-        ApiQueryBinder<BookApiDto> binder = new ApiQueryBinder<>(kakaoBinding());
-
-        return new KakaoBookProvider(apiQuerySender(), binder,loader);
-    }
-
-    @Bean
-    public BExistProvider bExistProvider(AuthKeyLoader loader){
-
-        ApiQueryBinder<ApiBookExistDto> binder = new ApiQueryBinder<>(bookExistBinding());
-
-        return new BExistProvider(apiQuerySender(),binder,loader);
-    }
-
-
 }
 

--- a/src/main/java/com/scaling/libraryservice/search/service/BookFinderImpl.java
+++ b/src/main/java/com/scaling/libraryservice/search/service/BookFinderImpl.java
@@ -15,6 +15,7 @@ import com.scaling.libraryservice.search.service.strategy.EngKorBoolSt;
 import com.scaling.libraryservice.search.service.strategy.EngKorNaturalSt;
 import com.scaling.libraryservice.search.service.strategy.KorBoolSt;
 import com.scaling.libraryservice.search.service.strategy.KorNaturalSt;
+import com.scaling.libraryservice.search.service.strategy.SelectStrategy;
 import com.scaling.libraryservice.search.util.TitleQuery;
 import com.scaling.libraryservice.search.util.TitleType;
 import java.util.EnumMap;
@@ -26,7 +27,7 @@ import org.springframework.stereotype.Component;
 @Component
 public class BookFinderImpl implements BookFinder<Page<BookDto>, Pageable>{
 
-    private final Map<TitleType,SelectStrategy> strategyMap;
+    private final Map<TitleType, SelectStrategy> strategyMap;
 
     public BookFinderImpl(BookRepository bookRepository) {
         this.strategyMap = new EnumMap<>(TitleType.class);

--- a/src/main/java/com/scaling/libraryservice/search/service/strategy/EngBoolSt.java
+++ b/src/main/java/com/scaling/libraryservice/search/service/strategy/EngBoolSt.java
@@ -2,7 +2,6 @@ package com.scaling.libraryservice.search.service.strategy;
 
 import com.scaling.libraryservice.search.entity.Book;
 import com.scaling.libraryservice.search.repository.BookRepository;
-import com.scaling.libraryservice.search.service.SelectStrategy;
 import com.scaling.libraryservice.search.util.TitleQuery;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;

--- a/src/main/java/com/scaling/libraryservice/search/service/strategy/EngKorBoolSt.java
+++ b/src/main/java/com/scaling/libraryservice/search/service/strategy/EngKorBoolSt.java
@@ -2,7 +2,6 @@ package com.scaling.libraryservice.search.service.strategy;
 
 import com.scaling.libraryservice.search.entity.Book;
 import com.scaling.libraryservice.search.repository.BookRepository;
-import com.scaling.libraryservice.search.service.SelectStrategy;
 import com.scaling.libraryservice.search.util.TitleQuery;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;

--- a/src/main/java/com/scaling/libraryservice/search/service/strategy/EngKorNaturalSt.java
+++ b/src/main/java/com/scaling/libraryservice/search/service/strategy/EngKorNaturalSt.java
@@ -2,7 +2,6 @@ package com.scaling.libraryservice.search.service.strategy;
 
 import com.scaling.libraryservice.search.entity.Book;
 import com.scaling.libraryservice.search.repository.BookRepository;
-import com.scaling.libraryservice.search.service.SelectStrategy;
 import com.scaling.libraryservice.search.util.TitleQuery;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;

--- a/src/main/java/com/scaling/libraryservice/search/service/strategy/EngNaturalSt.java
+++ b/src/main/java/com/scaling/libraryservice/search/service/strategy/EngNaturalSt.java
@@ -2,7 +2,6 @@ package com.scaling.libraryservice.search.service.strategy;
 
 import com.scaling.libraryservice.search.entity.Book;
 import com.scaling.libraryservice.search.repository.BookRepository;
-import com.scaling.libraryservice.search.service.SelectStrategy;
 import com.scaling.libraryservice.search.util.TitleQuery;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;

--- a/src/main/java/com/scaling/libraryservice/search/service/strategy/KorBoolSt.java
+++ b/src/main/java/com/scaling/libraryservice/search/service/strategy/KorBoolSt.java
@@ -2,7 +2,6 @@ package com.scaling.libraryservice.search.service.strategy;
 
 import com.scaling.libraryservice.search.entity.Book;
 import com.scaling.libraryservice.search.repository.BookRepository;
-import com.scaling.libraryservice.search.service.SelectStrategy;
 import com.scaling.libraryservice.search.util.TitleQuery;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;

--- a/src/main/java/com/scaling/libraryservice/search/service/strategy/KorNaturalSt.java
+++ b/src/main/java/com/scaling/libraryservice/search/service/strategy/KorNaturalSt.java
@@ -2,7 +2,6 @@ package com.scaling.libraryservice.search.service.strategy;
 
 import com.scaling.libraryservice.search.entity.Book;
 import com.scaling.libraryservice.search.repository.BookRepository;
-import com.scaling.libraryservice.search.service.SelectStrategy;
 import com.scaling.libraryservice.search.util.TitleQuery;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;

--- a/src/main/java/com/scaling/libraryservice/search/service/strategy/SelectStrategy.java
+++ b/src/main/java/com/scaling/libraryservice/search/service/strategy/SelectStrategy.java
@@ -1,4 +1,4 @@
-package com.scaling.libraryservice.search.service;
+package com.scaling.libraryservice.search.service.strategy;
 
 import com.scaling.libraryservice.search.entity.Book;
 import com.scaling.libraryservice.search.util.TitleQuery;

--- a/src/test/java/com/scaling/libraryservice/commons/api/service/KakaoBookProviderTest.java
+++ b/src/test/java/com/scaling/libraryservice/commons/api/service/KakaoBookProviderTest.java
@@ -1,7 +1,0 @@
-package com.scaling.libraryservice.commons.api.service;
-
-import static org.junit.jupiter.api.Assertions.*;
-
-class KakaoBookProviderTest {
-
-}

--- a/src/test/java/com/scaling/libraryservice/commons/api/util/ApiQueryBinderTest.java
+++ b/src/test/java/com/scaling/libraryservice/commons/api/util/ApiQueryBinderTest.java
@@ -3,6 +3,7 @@ package com.scaling.libraryservice.commons.api.util;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import com.scaling.libraryservice.commons.api.apiConnection.ApiConnection;
+import com.scaling.libraryservice.commons.api.service.provider.BExistProvider;
 import com.scaling.libraryservice.commons.api.util.binding.BookExistBinding;
 import com.scaling.libraryservice.mapBook.dto.ApiBookExistDto;
 import org.junit.jupiter.api.BeforeEach;
@@ -26,7 +27,7 @@ class ApiQueryBinderTest {
     @BeforeEach
     public void setUp(){
 
-        this.apiQueryBinder = new ApiQueryBinder<>(new BookExistBinding());
+        this.apiQueryBinder = new ApiQueryBinder<>();
     }
 
 
@@ -58,7 +59,7 @@ class ApiQueryBinderTest {
 
         var response = apiQuerySender.sendSingleQuery(apiConnection,HttpEntity.EMPTY);
 
-        var result = apiQueryBinder.bind(response);
+        var result = apiQueryBinder.bind(response, BExistProvider.class);
 
         /* then */
 


### PR DESCRIPTION
…> ApiQueryBinder에 map 형태로 전략 구현체를 가지고 전략 패턴을 적용하는 방식으로 변경.