### PR TITLE
feature : <SubstituteMethodValidator> 구현

### DIFF
--- a/src/main/java/com/scaling/libraryservice/commons/api/apiConnection/generator/ConnectionGenerator.java
+++ b/src/main/java/com/scaling/libraryservice/commons/api/apiConnection/generator/ConnectionGenerator.java
@@ -1,4 +1,4 @@
-package com.scaling.libraryservice.commons.api.service;
+package com.scaling.libraryservice.commons.api.apiConnection.generator;
 
 import com.scaling.libraryservice.commons.api.apiConnection.ApiConnection;
 import java.util.List;

--- a/src/main/java/com/scaling/libraryservice/commons/api/apiConnection/generator/LoanableLibConnGenerator.java
+++ b/src/main/java/com/scaling/libraryservice/commons/api/apiConnection/generator/LoanableLibConnGenerator.java
@@ -1,4 +1,4 @@
-package com.scaling.libraryservice.commons.api.service;
+package com.scaling.libraryservice.commons.api.apiConnection.generator;
 
 import com.scaling.libraryservice.commons.api.apiConnection.LoanableLibConn;
 import com.scaling.libraryservice.mapBook.dto.LibraryInfoDto;

--- a/src/main/java/com/scaling/libraryservice/commons/async/SearchAsyncExecutor.java
+++ b/src/main/java/com/scaling/libraryservice/commons/async/SearchAsyncExecutor.java
@@ -1,11 +1,7 @@
 package com.scaling.libraryservice.commons.async;
 
-import static com.scaling.libraryservice.search.dto.MetaDtoFactory.createDefaultMetaDto;
-
 import com.scaling.libraryservice.commons.caching.CustomCacheManager;
 import com.scaling.libraryservice.search.dto.BookDto;
-import com.scaling.libraryservice.search.dto.MetaDto;
-import com.scaling.libraryservice.search.dto.MetaDtoFactory;
 import com.scaling.libraryservice.search.dto.ReqBookDto;
 import com.scaling.libraryservice.search.dto.RespBooksDto;
 import com.scaling.libraryservice.search.dto.RespBooksDtoFactory;

--- a/src/main/java/com/scaling/libraryservice/commons/caching/CustomCacheManager.java
+++ b/src/main/java/com/scaling/libraryservice/commons/caching/CustomCacheManager.java
@@ -112,7 +112,7 @@ public class CustomCacheManager<K, I> {
      * @return 생성된 CacheKey 객체
      * @throws UnsupportedOperationException 적절한 CacheKey 구현을 찾지 못한 경우 던져 진다.
      */
-     CacheKey<K,I> generateCacheKey(@NonNull Object[] arguments) throws UnsupportedOperationException {
+    public CacheKey<K,I> generateCacheKey(@NonNull Object[] arguments) throws UnsupportedOperationException {
 
          return Arrays.stream(arguments)
              .filter(object -> object instanceof CacheKey<?,?>)

--- a/src/main/java/com/scaling/libraryservice/commons/caching/aop/CustomCacheAspect.java
+++ b/src/main/java/com/scaling/libraryservice/commons/caching/aop/CustomCacheAspect.java
@@ -1,6 +1,8 @@
-package com.scaling.libraryservice.commons.caching;
+package com.scaling.libraryservice.commons.caching.aop;
 
 import com.github.benmanes.caffeine.cache.Cache;
+import com.scaling.libraryservice.commons.caching.CacheKey;
+import com.scaling.libraryservice.commons.caching.CustomCacheManager;
 import com.scaling.libraryservice.mapBook.service.ApiRelatedService;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -10,7 +12,6 @@ import org.aspectj.lang.annotation.Aspect;
 import org.aspectj.lang.annotation.Pointcut;
 import org.springframework.lang.NonNull;
 import org.springframework.stereotype.Component;
-import org.springframework.util.StopWatch;
 
 /**
  * 사용자 정의 캐싱 어스펙트로, CustomCacheable 어노테이션이 적용된 메서드의 결과를 캐싱합니다. 캐싱된 데이터는 CustomCacheManager를 통해
@@ -31,7 +32,7 @@ public class CustomCacheAspect<K, I> {
     private final double CACHE_SEC_THRESHOLD = 2.0;
 
     @Pointcut("@annotation(co"
-        + "m.scaling.libraryservice.commons.caching.CustomCacheable)")
+        + "m.scaling.libraryservice.commons.caching.aop.CustomCacheable)")
     private void customCacheablePointcut() {
     }
 

--- a/src/main/java/com/scaling/libraryservice/commons/caching/aop/CustomCacheable.java
+++ b/src/main/java/com/scaling/libraryservice/commons/caching/aop/CustomCacheable.java
@@ -1,5 +1,6 @@
-package com.scaling.libraryservice.commons.caching;
+package com.scaling.libraryservice.commons.caching.aop;
 
+import com.scaling.libraryservice.commons.caching.CustomCacheManager;
 import java.lang.annotation.ElementType;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;

--- a/src/main/java/com/scaling/libraryservice/commons/circuitBreaker/ApiObserver.java
+++ b/src/main/java/com/scaling/libraryservice/commons/circuitBreaker/ApiObserver.java
@@ -1,8 +1,5 @@
 package com.scaling.libraryservice.commons.circuitBreaker;
 
-import com.scaling.libraryservice.commons.circuitBreaker.CircuitBreaker;
-import com.scaling.libraryservice.commons.circuitBreaker.ApiStatus;
-
 /**
  *  이 인터페이스 구현체는 ApiStatus를 멤버로 가지며, {@link CircuitBreaker}
  *  에게 서버 장애 관련해서 관리 받을 수 있는 인터페이스

--- a/src/main/java/com/scaling/libraryservice/commons/circuitBreaker/CircuitBreaker.java
+++ b/src/main/java/com/scaling/libraryservice/commons/circuitBreaker/CircuitBreaker.java
@@ -2,6 +2,7 @@ package com.scaling.libraryservice.commons.circuitBreaker;
 
 import static java.util.concurrent.TimeUnit.SECONDS;
 
+import com.scaling.libraryservice.commons.circuitBreaker.restoration.RestorationChecker;
 import com.scaling.libraryservice.logging.logger.OpenApiLogger;
 import java.util.Map;
 import java.util.concurrent.ScheduledExecutorService;
@@ -32,7 +33,7 @@ public class CircuitBreaker {
      * @param apiObserver API 액세스 상태를 확인할 {@link ApiObserver} 인스턴스
      * @return {@link ApiObserver}가 가리키는 API가 접근 가능한 경우 true, 그렇지 않은 경우 false를 반환
      */
-    boolean isApiAccessible(@NonNull ApiObserver apiObserver) {
+    public boolean isApiAccessible(@NonNull ApiObserver apiObserver) {
         return apiObserver.getApiStatus().apiAccessible();
     }
 
@@ -42,7 +43,7 @@ public class CircuitBreaker {
      *
      * @param observer 발생한 오류를 처리할 {@link ApiObserver} 인스턴스
      */
-    synchronized void receiveError(@NonNull ApiObserver observer) {
+    public synchronized void receiveError(@NonNull ApiObserver observer) {
 
         ApiStatus status = observer.getApiStatus();
         status.upErrorCnt();

--- a/src/main/java/com/scaling/libraryservice/commons/circuitBreaker/CircuitBreakerAspect.java
+++ b/src/main/java/com/scaling/libraryservice/commons/circuitBreaker/CircuitBreakerAspect.java
@@ -9,6 +9,7 @@ import org.aspectj.lang.annotation.Around;
 import org.aspectj.lang.annotation.Aspect;
 import org.aspectj.lang.annotation.Pointcut;
 import org.aspectj.lang.reflect.MethodSignature;
+import org.springframework.core.annotation.AnnotationUtils;
 import org.springframework.lang.NonNull;
 import org.springframework.stereotype.Component;
 
@@ -48,17 +49,20 @@ public class CircuitBreakerAspect {
         Method joinPointMethod = ((MethodSignature) joinPoint.getSignature()).getMethod();
         ApiMonitoring apiMonitoring = joinPointMethod.getAnnotation(ApiMonitoring.class);
 
+
         Method[] methods = joinPoint.getTarget().getClass().getDeclaredMethods();
 
         ApiObserver apiObserver = support.extractObserver(apiMonitoring);
         Method fallBackMethod = support.extractSubstituteMethod(apiMonitoring, methods);
 
         if (!circuitBreaker.isApiAccessible(apiObserver)) {
+
             return fallBackMethod.invoke(joinPoint.getTarget(), joinPoint.getArgs());
         } else {
 
             try {
                 return joinPoint.proceed();
+
             } catch (OpenApiException e) {
                 circuitBreaker.receiveError(apiObserver);
                 fallBackMethod.setAccessible(true);

--- a/src/main/java/com/scaling/libraryservice/commons/circuitBreaker/CircuitBreakerSupporter.java
+++ b/src/main/java/com/scaling/libraryservice/commons/circuitBreaker/CircuitBreakerSupporter.java
@@ -6,7 +6,6 @@ import java.lang.reflect.Method;
 import java.util.Arrays;
 import java.util.HashMap;
 import java.util.Map;
-import java.util.Optional;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.lang.NonNull;
 import org.springframework.stereotype.Component;
@@ -49,7 +48,7 @@ public class CircuitBreakerSupporter {
             constructAndPutObserver(apiMonitoring, observerClazz);
     }
 
-    private ApiObserver constructAndPutObserver(ApiMonitoring apiMonitoring,
+    ApiObserver constructAndPutObserver(ApiMonitoring apiMonitoring,
         Class<? extends ApiObserver> observerClazz) throws Exception {
 
         Constructor<? extends ApiObserver> constructor =

--- a/src/main/java/com/scaling/libraryservice/commons/circuitBreaker/SubstituteMethodValidator.java
+++ b/src/main/java/com/scaling/libraryservice/commons/circuitBreaker/SubstituteMethodValidator.java
@@ -1,0 +1,42 @@
+package com.scaling.libraryservice.commons.circuitBreaker;
+
+import com.scaling.libraryservice.commons.circuitBreaker.exception.SubstituteMethodException;
+import java.lang.reflect.Method;
+import java.util.Arrays;
+import lombok.NonNull;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.config.BeanPostProcessor;
+import org.springframework.stereotype.Component;
+
+@RequiredArgsConstructor
+@Component
+public class SubstituteMethodValidator implements BeanPostProcessor {
+
+    private final CircuitBreakerSupporter circuitBreakerSupporter;
+
+    @Override // @ApiMonitoring에서 substitute()에 매칭 되는 메소드가 없는 경우 서버를 시작하며 에러를 발생
+    public Object postProcessBeforeInitialization(Object bean, @NonNull String beanName) {
+
+        Method[] methods = bean.getClass().getMethods();
+
+        Arrays.stream(methods).forEach(method -> {
+            ApiMonitoring apiMonitoring = method.getAnnotation(ApiMonitoring.class);
+
+            if (apiMonitoring != null) {
+                try {
+                    circuitBreakerSupporter.extractSubstituteMethod(apiMonitoring, methods);
+                } catch (IllegalArgumentException e) {
+
+                    throw new SubstituteMethodException(
+                        "Invalid substitute method name "
+                            + apiMonitoring.substitute()
+                            + " in bean "
+                            + beanName
+                    );
+                }
+            }}
+        );
+
+        return bean;
+    }
+}

--- a/src/main/java/com/scaling/libraryservice/commons/circuitBreaker/exception/SubstituteMethodException.java
+++ b/src/main/java/com/scaling/libraryservice/commons/circuitBreaker/exception/SubstituteMethodException.java
@@ -1,0 +1,11 @@
+package com.scaling.libraryservice.commons.circuitBreaker.exception;
+
+public class SubstituteMethodException extends RuntimeException {
+
+    public SubstituteMethodException() {
+    }
+
+    public SubstituteMethodException(String message) {
+        super(message);
+    }
+}

--- a/src/main/java/com/scaling/libraryservice/commons/circuitBreaker/restoration/ApiQuerySendChecker.java
+++ b/src/main/java/com/scaling/libraryservice/commons/circuitBreaker/restoration/ApiQuerySendChecker.java
@@ -1,7 +1,8 @@
-package com.scaling.libraryservice.commons.circuitBreaker;
+package com.scaling.libraryservice.commons.circuitBreaker.restoration;
 
 import com.scaling.libraryservice.commons.api.util.ApiQuerySender;
 import com.scaling.libraryservice.commons.api.apiConnection.ApiConnection;
+import com.scaling.libraryservice.commons.circuitBreaker.ApiObserver;
 import com.scaling.libraryservice.mapBook.exception.OpenApiException;
 import java.time.LocalDateTime;
 import lombok.RequiredArgsConstructor;
@@ -11,7 +12,7 @@ import org.springframework.lang.NonNull;
 import org.springframework.web.util.UriComponentsBuilder;
 
 /**
- * {@link QuerySendChecker} 클래스는 {@link RestorationChecker} 인터페이스를 구현하여
+ * {@link ApiQuerySendChecker} 클래스는 {@link RestorationChecker} 인터페이스를 구현하여
  * API 서버의 상태를 확인하고, 해당 API 서버가 접근 가능한 상태로 복원될 수 있는지 확인합니다.
  * 이 클래스는 {@link ApiQuerySender} 인스턴스를 사용하여 API 서버에 테스트 쿼리를 보냅니다.
  *
@@ -20,7 +21,7 @@ import org.springframework.web.util.UriComponentsBuilder;
  */
 @Slf4j
 @RequiredArgsConstructor
-public class QuerySendChecker implements RestorationChecker{
+public class ApiQuerySendChecker implements RestorationChecker{
 
     private final ApiQuerySender apiQuerySender;
 

--- a/src/main/java/com/scaling/libraryservice/commons/circuitBreaker/restoration/RestorationChecker.java
+++ b/src/main/java/com/scaling/libraryservice/commons/circuitBreaker/restoration/RestorationChecker.java
@@ -1,4 +1,6 @@
-package com.scaling.libraryservice.commons.circuitBreaker;
+package com.scaling.libraryservice.commons.circuitBreaker.restoration;
+
+import com.scaling.libraryservice.commons.circuitBreaker.ApiObserver;
 
 /**
  * RestorationChecker는 특정 API 호출의 복구 가능성을 확인하는 역할을 합니다.

--- a/src/main/java/com/scaling/libraryservice/config/AppConfig.java
+++ b/src/main/java/com/scaling/libraryservice/config/AppConfig.java
@@ -4,8 +4,8 @@ package com.scaling.libraryservice.config;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import com.scaling.libraryservice.commons.api.util.ApiQuerySender;
 import com.scaling.libraryservice.commons.circuitBreaker.CircuitBreaker;
-import com.scaling.libraryservice.commons.circuitBreaker.QuerySendChecker;
-import com.scaling.libraryservice.commons.circuitBreaker.RestorationChecker;
+import com.scaling.libraryservice.commons.circuitBreaker.restoration.ApiQuerySendChecker;
+import com.scaling.libraryservice.commons.circuitBreaker.restoration.RestorationChecker;
 import com.scaling.libraryservice.logging.logger.OpenApiLogger;
 import com.scaling.libraryservice.search.engine.filter.StopWordFilter;
 import com.scaling.libraryservice.search.service.KeywordService;
@@ -69,7 +69,7 @@ public class AppConfig {
     @Bean
     public RestorationChecker restorationChecker() {
 
-        return new QuerySendChecker(apiQuerySenderTimeOut());
+        return new ApiQuerySendChecker(apiQuerySenderTimeOut());
     }
 
     @Bean

--- a/src/main/java/com/scaling/libraryservice/dataPipe/aop/BatchLoggingAspect.java
+++ b/src/main/java/com/scaling/libraryservice/dataPipe/aop/BatchLoggingAspect.java
@@ -13,7 +13,7 @@ import org.springframework.stereotype.Component;
 @Aspect
 @Component
 @RequiredArgsConstructor
-public class BatchLoggingAop {
+public class BatchLoggingAspect {
 
     private final BatchLogger batchLogger;
 

--- a/src/main/java/com/scaling/libraryservice/mapBook/controller/MapBookController.java
+++ b/src/main/java/com/scaling/libraryservice/mapBook/controller/MapBookController.java
@@ -6,7 +6,7 @@ import com.scaling.libraryservice.logging.logger.MapBookLogger;
 import com.scaling.libraryservice.mapBook.dto.LibraryInfoDto;
 import com.scaling.libraryservice.mapBook.dto.ReqMapBookDto;
 import com.scaling.libraryservice.mapBook.dto.RespMapBookDto;
-import com.scaling.libraryservice.commons.api.service.ConnectionGenerator;
+import com.scaling.libraryservice.commons.api.apiConnection.generator.ConnectionGenerator;
 import com.scaling.libraryservice.mapBook.dto.RespMapBookWrapper;
 import com.scaling.libraryservice.mapBook.service.LibraryFindService;
 import com.scaling.libraryservice.mapBook.service.MapBookService;

--- a/src/main/java/com/scaling/libraryservice/mapBook/service/MapBookService.java
+++ b/src/main/java/com/scaling/libraryservice/mapBook/service/MapBookService.java
@@ -2,7 +2,7 @@ package com.scaling.libraryservice.mapBook.service;
 
 import com.scaling.libraryservice.commons.api.apiConnection.LoanableLibConn;
 import com.scaling.libraryservice.commons.api.service.provider.DataProvider;
-import com.scaling.libraryservice.commons.caching.CustomCacheable;
+import com.scaling.libraryservice.commons.caching.aop.CustomCacheable;
 import com.scaling.libraryservice.commons.timer.MeasureTaskTime;
 import com.scaling.libraryservice.mapBook.dto.ApiLoanableLibDto;
 import com.scaling.libraryservice.mapBook.dto.LibraryInfoDto;

--- a/src/main/java/com/scaling/libraryservice/search/service/BookSearchService.java
+++ b/src/main/java/com/scaling/libraryservice/search/service/BookSearchService.java
@@ -6,7 +6,7 @@ import static com.scaling.libraryservice.search.dto.RespBooksDtoFactory.createIs
 import static com.scaling.libraryservice.search.dto.RespBooksDtoFactory.createOneBookRespDto;
 
 import com.scaling.libraryservice.commons.async.AsyncExecutor;
-import com.scaling.libraryservice.commons.caching.CustomCacheable;
+import com.scaling.libraryservice.commons.caching.aop.CustomCacheable;
 import com.scaling.libraryservice.commons.timer.MeasureTaskTime;
 import com.scaling.libraryservice.search.dto.BookDto;
 import com.scaling.libraryservice.search.dto.ReqBookDto;

--- a/src/test/java/com/scaling/libraryservice/LibraryServiceApplicationTests.java
+++ b/src/test/java/com/scaling/libraryservice/LibraryServiceApplicationTests.java
@@ -3,14 +3,13 @@ package com.scaling.libraryservice;
 import static com.scaling.libraryservice.dataPipe.download.LibraryCatalogDownloader.getDefaultDirectory;
 
 import com.scaling.libraryservice.dataPipe.csv.exporter.BookExporter;
+import com.scaling.libraryservice.dataPipe.download.LibraryCatalogDownloader;
 import com.scaling.libraryservice.dataPipe.libraryCatalog.LibraryCatalogManager;
 import com.scaling.libraryservice.dataPipe.libraryCatalog.LibraryCatalogNormalizer;
-import com.scaling.libraryservice.dataPipe.download.LibraryCatalogDownloader;
 import com.scaling.libraryservice.dataPipe.updater.service.BookUpdateService;
 import com.scaling.libraryservice.search.engine.TitleAnalyzer;
 import java.io.IOException;
 import org.junit.jupiter.api.DisplayName;
-import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 

--- a/src/test/java/com/scaling/libraryservice/commons/caching/CustomCacheAspectTest.java
+++ b/src/test/java/com/scaling/libraryservice/commons/caching/CustomCacheAspectTest.java
@@ -7,6 +7,7 @@ import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+import com.scaling.libraryservice.commons.caching.aop.CustomCacheAspect;
 import com.scaling.libraryservice.mapBook.dto.ReqMapBookDto;
 import com.scaling.libraryservice.mapBook.dto.RespMapBookDto;
 import com.scaling.libraryservice.mapBook.service.MapBookService;

--- a/src/test/java/com/scaling/libraryservice/commons/circuitBreaker/ApiQuerySendCheckerTest.java
+++ b/src/test/java/com/scaling/libraryservice/commons/circuitBreaker/ApiQuerySendCheckerTest.java
@@ -6,6 +6,7 @@ import static org.mockito.Mockito.any;
 import static org.mockito.Mockito.when;
 
 import com.scaling.libraryservice.commons.api.util.ApiQuerySender;
+import com.scaling.libraryservice.commons.circuitBreaker.restoration.ApiQuerySendChecker;
 import com.scaling.libraryservice.mapBook.exception.OpenApiException;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -17,10 +18,10 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 
 @ExtendWith(MockitoExtension.class)
-class QuerySendCheckerTest {
+class ApiQuerySendCheckerTest {
 
     @InjectMocks
-    private QuerySendChecker checker;
+    private ApiQuerySendChecker checker;
 
     @Mock
     private ApiQuerySender apiQuerySender;

--- a/src/test/java/com/scaling/libraryservice/commons/circuitBreaker/CircuitBreakerTest.java
+++ b/src/test/java/com/scaling/libraryservice/commons/circuitBreaker/CircuitBreakerTest.java
@@ -12,6 +12,7 @@ import static org.mockito.Mockito.when;
 
 import com.github.tomakehurst.wiremock.WireMockServer;
 import com.github.tomakehurst.wiremock.client.WireMock;
+import com.scaling.libraryservice.commons.circuitBreaker.restoration.RestorationChecker;
 import com.scaling.libraryservice.logging.logger.OpenApiLogger;
 import java.util.Map;
 import java.util.concurrent.ExecutorService;

--- a/src/test/java/com/scaling/libraryservice/mapBook/service/LoanableLibConnGeneratorTest.java
+++ b/src/test/java/com/scaling/libraryservice/mapBook/service/LoanableLibConnGeneratorTest.java
@@ -2,7 +2,7 @@ package com.scaling.libraryservice.mapBook.service;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
-import com.scaling.libraryservice.commons.api.service.LoanableLibConnGenerator;
+import com.scaling.libraryservice.commons.api.apiConnection.generator.LoanableLibConnGenerator;
 import com.scaling.libraryservice.mapBook.dto.LibraryInfoDto;
 import com.scaling.libraryservice.mapBook.dto.ReqMapBookDto;
 import java.util.Arrays;


### PR DESCRIPTION
- circuit breaker 기능을 선택 하는 클래스에서 잘못된 substituteMethod 이름을 지정 했을 때, BeanPostProcessor를 구현한 SubstituteMethodValidator를 통해 서버 시작하면서 유효성 검사를 실시 한다. 유효성 검사를 실패하면 SubstituteMethodException 반환하여 서버 시작이 되지 않도록 막는다.