### PR TITLE
fix : MapBookService의 메소드 중 전달 받은 ApiConnection 객체를 통해서 Api와 통신하게 되는데…

### DIFF
--- a/src/main/java/com/scaling/libraryservice/mapBook/service/MapBookService.java
+++ b/src/main/java/com/scaling/libraryservice/mapBook/service/MapBookService.java
@@ -63,15 +63,17 @@ public class MapBookService implements ApiRelatedService {
             reqMapBookDto
         );
 
+        if(loanableLibConns.isEmpty()){
+            return notFoundLoanableLib(nearByLibraries, reqMapBookDto);
+        }
+
         // 대출 가능 데이터를 전달 받는다.
         List<ApiLoanableLibDto> apiResults = dataProvider.provideDataList(
             loanableLibConns,
             loanableLibConns.size()
         );
 
-        return loanableLibConns.isEmpty() ?
-            notFoundLoanableLib(nearByLibraries, reqMapBookDto) :
-            mappingLoanableLib(nearByLibraries, apiResults);
+        return mappingLoanableLib(nearByLibraries, apiResults);
     }
 
     private List<RespMapBookDto> notFoundLoanableLib(List<LibraryInfoDto> nearByLibraries,


### PR DESCRIPTION
…, 이때 dataProvider에게 worker Thread의 수를 Connection 객체 size만큼으로 동적으로 변경해서 제공 한다. 문제는 size가 0일 때, ExecutorService에게 명시하는 사이즈 수가 0이기 때문에 IllegalArgumentException가 발생하고, Front단에선 An error occurred: [object Object] 의 메시지가 반환 됐었다

따라서 해결은 Api 통신 객체를 호출하기 전에 조건 분기로 size가 0일 때를 체크해서 따로 처리한다.